### PR TITLE
Fix switched expected & provided values

### DIFF
--- a/src/HttpAssert.php
+++ b/src/HttpAssert.php
@@ -78,7 +78,7 @@ class HttpAssert
         string $message = ''
     ): Document
     {
-        PHPUnitAssert::assertSame($type, $expected, $message ?: "Expecting content with media type {$expected}.");
+        PHPUnitAssert::assertSame($expected, $type, $message ?: "Expecting content with media type {$expected}.");
         PHPUnitAssert::assertNotEmpty($content, $message ?: 'Expecting HTTP body to have content.');
 
         return Document::cast($content);


### PR DESCRIPTION
PHPUnitAssert::assertSame 's first paramter is the expected value, assertContent should thus provide the expected value as first parameter.