### PR TITLE
Support for PHPUnit 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 matrix:
   include:
-    - php: "7.1"
+    - php: "7.2"
       env:
         - LARAVEL_VERSION=5.8.*
         - PHPUNIT_VERSION=^7.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ matrix:
   include:
     - php: "7.2"
       env:
-        - LARAVEL_VERSION=5.8.*
-        - PHPUNIT_VERSION=^8.0
-    - php: "7.2"
-      env:
         - LARAVEL_VERSION=^6.0
         - PHPUNIT_VERSION=^8.0
     - php: "7.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ matrix:
       env:
         - LARAVEL_VERSION=^7.0
         - PHPUNIT_VERSION=^8.0
+    - php: "7.3"
+      env:
+        - LARAVEL_VERSION=^7.0
+        - PHPUNIT_VERSION=^9.0
 
 install:
   - composer require "illuminate/support:${LARAVEL_VERSION}" --no-update -n

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - php: "7.2"
       env:
         - LARAVEL_VERSION=5.8.*
-        - PHPUNIT_VERSION=^7.5
+        - PHPUNIT_VERSION=^8.0
     - php: "7.2"
       env:
         - LARAVEL_VERSION=^6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ matrix:
       env:
         - LARAVEL_VERSION=^7.0
         - PHPUNIT_VERSION=^9.0
+    - php: "7.4"
+      env:
+        - LARAVEL_VERSION=^7.0
+        - PHPUNIT_VERSION=^9.0
 
 install:
   - composer require "illuminate/support:${LARAVEL_VERSION}" --no-update -n

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.1",
         "ext-json": "*",
         "illuminate/support": "^5.8|^6.0|^7.0",
-        "phpunit/phpunit": "^7.5|^8.0"
+        "phpunit/phpunit": "^7.5|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "illuminate/support": "5.8.*|^6.0|^7.0",
+        "illuminate/support": "^6.0|^7.0",
         "phpunit/phpunit": "^8.0|^9.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "illuminate/support": "^5.8|^6.0|^7.0",
-        "phpunit/phpunit": "^7.5|^8.0|^9.0"
+        "illuminate/support": "5.8.*|^6.0|^7.0",
+        "phpunit/phpunit": "^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "ext-json": "*",
         "illuminate/support": "^5.8|^6.0|^7.0",
         "phpunit/phpunit": "^7.5|^8.0|^9.0"

--- a/src/Constraints/ExactInDocument.php
+++ b/src/Constraints/ExactInDocument.php
@@ -63,7 +63,7 @@ class ExactInDocument extends Constraint
     /**
      * @inheritdoc
      */
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {
         $actual = Document::cast($other)->get($this->pointer);
         $result = Compare::exact($this->expected, $actual, $this->strict);
@@ -75,6 +75,8 @@ class ExactInDocument extends Constraint
         if (!$result) {
             $this->fail($other, $description, Compare::failure($this->expected, $actual));
         }
+
+        return null;
     }
 
     /**

--- a/src/Constraints/SubsetInDocument.php
+++ b/src/Constraints/SubsetInDocument.php
@@ -64,7 +64,7 @@ class SubsetInDocument extends Constraint
     /**
      * @inheritdoc
      */
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {
         $actual = Document::cast($other)->get($this->pointer);
         $result = $this->compare($this->expected, $actual, $this->strict);
@@ -80,6 +80,8 @@ class SubsetInDocument extends Constraint
                 $this->failure($actual)
             );
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
### About
First pass at adding support for PHPUnit 9.0 suggested in #11.

_BC break when running the following stack:_
- `php:7.1`
- `laravel:5.8`
- `phpunit:7.5`

### Changes
- Remove support for `php:^7.1`
- Remove support for `phpunit:^7.5`
- Add support for `phpunit:^9.0`

### Reasoning
- Discontinued support for php71 as reached is EOL 1. December 2019.
  - Could cause conflicts with `cloudcreativity/laravel-json-api:1.6` as it allows php71
- Discontinued support for PHPUnit 7, as `cloudcreativity/laravel-json-api:1.6` supports PHPUnit 8
  - And the contract changes in the PHPUnit's abstract `Constraint`-class are not backwards compatible

--

**NB:** Please do not hesitate requesting changes as I've made some bold decisions that ultimately are not mine to take.