### PR TITLE
Add support for PHPUnit 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,15 +14,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, '8.0', 8.1, 8.2]
-        laravel: [8, 9, 10]
-        exclude:
-          - php: 7.4
-            laravel: 9
-          - php: 7.4
-            laravel: 10
-          - php: '8.0'
-            laravel: 10
+        php: [8.1, 8.2]
+        laravel: [9, 10]
+        phpunit: [9.5, 10]
 
     steps:
     - name: Checkout Code
@@ -38,6 +32,9 @@ jobs:
 
     - name: Set Laravel Version
       run: composer require "illuminate/contracts:^${{ matrix.laravel }}" --no-update
+
+    - name: Set PHPUnit Version
+      run: composer require "phpunit/phpunit:^${{ matrix.laravel }}" --no-update
 
     - name: Install dependencies
       uses: nick-fields/retry@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 .phpunit.result.cache
+.phpunit.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
+## Unreleased
+
+### Changed
+
+- Package now supports PHPUnit 9 and 10 - this adds PHPUnit 10 and drops support for PHPUnit 8.
+- Minimum PHP version is now 8.1 - dropping support for PHP 7.4 and 8.0.
+- Drop support for Laravel 8.
+
 ## [4.1.0] - 2023-02-14
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "ext-json": "*",
-        "illuminate/contracts": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0",
-        "phpunit/phpunit": "^9.5.10"
+        "illuminate/contracts": "^9.0|^10.0",
+        "illuminate/support": "^9.0|^10.0",
+        "phpunit/phpunit": "^9.5.10|^10.0"
     },
     "autoload": {
         "psr-4": {
@@ -39,7 +39,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "4.x-dev"
+            "dev-develop": "5.x-dev"
         }
     },
     "minimum-stability": "stable",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false"
+         beStrictAboutTestsThatDoNotTestAnything="true" bootstrap="vendor/autoload.php" colors="true"
+         processIsolation="false" stopOnError="false" stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
     <coverage>
         <include>
             <directory suffix="Test.php">src/</directory>

--- a/src/Constraints/OnlyExactInList.php
+++ b/src/Constraints/OnlyExactInList.php
@@ -34,7 +34,7 @@ class OnlyExactInList extends OnlySubsetsInList
     /**
      * @inheritdoc
      */
-    protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): void
+    protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): never
     {
         $comparisonFailure = Compare::failure(
             $this->expected,

--- a/src/Constraints/OnlyIdentifiersInList.php
+++ b/src/Constraints/OnlyIdentifiersInList.php
@@ -34,7 +34,7 @@ class OnlyIdentifiersInList extends OnlySubsetsInList
     /**
      * @inheritdoc
      */
-    protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): void
+    protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): never
     {
         $comparisonFailure = Compare::failure(
             $this->expected,

--- a/src/Constraints/OnlySubsetsInList.php
+++ b/src/Constraints/OnlySubsetsInList.php
@@ -100,7 +100,7 @@ class OnlySubsetsInList extends Constraint
     /**
      * @inheritdoc
      */
-    protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): void
+    protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): never
     {
         if (!$comparisonFailure) {
             $comparisonFailure = Compare::failure(

--- a/tests/Assertions/FetchedManyTest.php
+++ b/tests/Assertions/FetchedManyTest.php
@@ -231,7 +231,7 @@ class FetchedManyTest extends TestCase
     /**
      * @return array
      */
-    public function fetchedManyArrayProvider(): array
+    public static function fetchedManyArrayProvider(): array
     {
         return [
             'identifiers (any order)' => [
@@ -515,7 +515,7 @@ class FetchedManyTest extends TestCase
     /**
      * @return array
      */
-    public function fetchedManyInOrderArrayProvider(): array
+    public static function fetchedManyInOrderArrayProvider(): array
     {
         return [
             'identifiers' => [
@@ -777,7 +777,7 @@ class FetchedManyTest extends TestCase
     /**
      * @return array
      */
-    public function fetchedManyExactArrayProvider(): array
+    public static function fetchedManyExactArrayProvider(): array
     {
         return [
             'identifiers' => [

--- a/tests/Assertions/FetchedOneTest.php
+++ b/tests/Assertions/FetchedOneTest.php
@@ -130,7 +130,7 @@ class FetchedOneTest extends TestCase
     /**
      * @return array
      */
-    public function fetchedOneArrayProvider(): array
+    public static function fetchedOneArrayProvider(): array
     {
         return [
             'identifier' => [
@@ -326,7 +326,7 @@ class FetchedOneTest extends TestCase
     /**
      * @return array
      */
-    public function fetchedOneExactArrayProvider(): array
+    public static function fetchedOneExactArrayProvider(): array
     {
         return [
             'identifier' => [

--- a/tests/Assertions/FetchedToManyTest.php
+++ b/tests/Assertions/FetchedToManyTest.php
@@ -165,7 +165,7 @@ class FetchedToManyTest extends TestCase
     /**
      * @return array[]
      */
-    public function fetchedToManyArrayProvider(): array
+    public static function fetchedToManyArrayProvider(): array
     {
         return [
             'in order' => [
@@ -349,7 +349,7 @@ class FetchedToManyTest extends TestCase
     /**
      * @return array[]
      */
-    public function fetchedToManyInOrderArrayProvider(): array
+    public static function fetchedToManyInOrderArrayProvider(): array
     {
         return [
             'in order' => [

--- a/tests/Assertions/FetchedToOneTest.php
+++ b/tests/Assertions/FetchedToOneTest.php
@@ -110,7 +110,7 @@ class FetchedToOneTest extends TestCase
     /**
      * @return array
      */
-    public function fetchedToOneArrayProvider(): array
+    public static function fetchedToOneArrayProvider(): array
     {
         return [
             'identifier' => [
@@ -183,7 +183,7 @@ class FetchedToOneTest extends TestCase
     /**
      * @return array[]
      */
-    public function resourceProvider(): array
+    public static function resourceProvider(): array
     {
         return [
             'full' => [

--- a/tests/Assertions/IncludedTest.php
+++ b/tests/Assertions/IncludedTest.php
@@ -134,7 +134,7 @@ class IncludedTest extends TestCase
     /**
      * @return array
      */
-    public function isIncludedProvider(): array
+    public static function isIncludedProvider(): array
     {
         return [
             'author' => [

--- a/tests/Assertions/MetaTest.php
+++ b/tests/Assertions/MetaTest.php
@@ -77,7 +77,7 @@ class MetaTest extends TestCase
     /**
      * @return array
      */
-    public function statusCodeProvider(): array
+    public static function statusCodeProvider(): array
     {
         return [
             '200' => [200],
@@ -148,7 +148,7 @@ class MetaTest extends TestCase
     /**
      * @return array
      */
-    public function invalidStatusCodeProvider(): array
+    public static function invalidStatusCodeProvider(): array
     {
         return [
             '100' => [100],


### PR DESCRIPTION
This PR:

- Adds support for PHPUnit 10
- Drops support for Laravel 8
- Drops support for PHPUnit 8
- Drops support for PHP 7.4 and 8.0