### PR TITLE
Feature: amend supported PHPUnit versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2]
-        laravel: [9, 10]
-        phpunit: [9.5, 10]
+        php: [8.2, 8.3]
+        laravel: [10, 11]
+        phpunit: [10.5, 11]
 
     steps:
     - name: Checkout Code

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 vendor/
 composer.lock
-.phpunit.result.cache
-.phpunit.cache
+.phpunit.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
+## Unreleased (Laravel 11)
+
+### Changed
+
+- **BREAKING** Package now requires Laravel 10 or 11, dropping support for 9.
+- **BREAKING** Package now requires PHPUnit 10 or 11, dropping support for 9.
+- Minimum PHP version is now `8.2`.
+
 ## [5.0.0] - 2023-02-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Changed
 
-- **BREAKING** Package now requires Laravel 10 or 11, dropping support for 9.
+- **BREAKING** Package now requires `illuminate/support` 10 or 11, dropping support for 9.
 - **BREAKING** Package now requires PHPUnit 10 or 11, dropping support for 9.
 - Minimum PHP version is now `8.2`.
 

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
             "dev-laravel11": "6.x-dev"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
-        "illuminate/contracts": "^9.0|^10.0",
-        "illuminate/support": "^9.0|^10.0",
-        "phpunit/phpunit": "^9.5.10|^10.0"
+        "illuminate/contracts": "^11.0",
+        "illuminate/support": "^11.0",
+        "phpunit/phpunit": "^10.5|^11.0"
     },
     "autoload": {
         "psr-4": {
@@ -39,10 +39,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "5.x-dev"
+            "dev-develop": "5.x-dev",
+            "dev-laravel11": "6.x-dev"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "5.x-dev",
-            "dev-laravel11": "6.x-dev"
+            "dev-develop": "6.x-dev"
         }
     },
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "illuminate/contracts": "^11.0",
-        "illuminate/support": "^11.0",
+        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0",
         "phpunit/phpunit": "^10.5|^11.0"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
          cacheDirectory=".phpunit.cache"
          backupStaticProperties="false"
          failOnWarning="true"
-         failOnDeprecation="true"
+         failOnDeprecation="false"
          failOnNotice="true"
 >
     <coverage/>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false"
-         beStrictAboutTestsThatDoNotTestAnything="true" bootstrap="vendor/autoload.php" colors="true"
-         processIsolation="false" stopOnError="false" stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache"
-         backupStaticProperties="false">
-    <coverage>
-        <include>
-            <directory suffix="Test.php">src/</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false"
+         failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+>
+    <coverage/>
     <testsuites>
         <testsuite name="Unit">
             <directory>./tests/</directory>
@@ -17,4 +23,9 @@
     <php>
         <ini name="error_reporting" value="E_ALL"/>
     </php>
+    <source>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
This drops support for PHPUnit 9 and adds in support for PHPUnit 11. Also sets minimum PHP version to 8.2, dropping 8.1 - plus amends the Illuminate packages to 10 or 11 (dropping 9).