### PR TITLE
Fix: remove deprecation notices from PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
         laravel: [10, 11]
         phpunit: [10.5, 11]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file. This projec
 
 ## Unreleased
 
+### Fixed
+
+- Remove deprecation notices from PHP 8.4.
+
 ## [6.0.0] - 2024-03-12
 
 ### Changed

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,7 @@
          failOnWarning="true"
          failOnDeprecation="false"
          failOnNotice="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
 >
     <coverage/>
     <testsuites>

--- a/src/Constraints/HttpStatusIsSuccessful.php
+++ b/src/Constraints/HttpStatusIsSuccessful.php
@@ -32,7 +32,7 @@ class HttpStatusIsSuccessful extends Constraint
      *
      * @param string|null $content
      */
-    public function __construct(string $content = null)
+    public function __construct(?string $content = null)
     {
         $this->content = $content;
     }

--- a/src/Constraints/OnlyExactInList.php
+++ b/src/Constraints/OnlyExactInList.php
@@ -26,7 +26,7 @@ class OnlyExactInList extends OnlySubsetsInList
     /**
      * @inheritdoc
      */
-    protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): never
+    protected function fail($other, $description, ?ComparisonFailure $comparisonFailure = null): never
     {
         $comparisonFailure = Compare::failure(
             $this->expected,

--- a/src/Constraints/OnlyIdentifiersInList.php
+++ b/src/Constraints/OnlyIdentifiersInList.php
@@ -26,7 +26,7 @@ class OnlyIdentifiersInList extends OnlySubsetsInList
     /**
      * @inheritdoc
      */
-    protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): never
+    protected function fail($other, $description, ?ComparisonFailure $comparisonFailure = null): never
     {
         $comparisonFailure = Compare::failure(
             $this->expected,

--- a/src/Constraints/OnlySubsetsInList.php
+++ b/src/Constraints/OnlySubsetsInList.php
@@ -92,7 +92,7 @@ class OnlySubsetsInList extends Constraint
     /**
      * @inheritdoc
      */
-    protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): never
+    protected function fail($other, $description, ?ComparisonFailure $comparisonFailure = null): never
     {
         if (!$comparisonFailure) {
             $comparisonFailure = Compare::failure(

--- a/src/HttpAssert.php
+++ b/src/HttpAssert.php
@@ -50,7 +50,7 @@ class HttpAssert
     public static function assertStatusCode(
         $status,
         int $expected,
-        string $content = null,
+        ?string $content = null,
         string $message = ''
     ): void
     {
@@ -562,7 +562,7 @@ class HttpAssert
      * @param string $message
      * @return void
      */
-    public static function assertNoContent($status, string $content = null, string $message = ''): void
+    public static function assertNoContent($status, ?string $content = null, string $message = ''): void
     {
         self::assertStatusCode($status, self::STATUS_NO_CONTENT, $content, $message);
         PHPUnitAssert::assertEmpty($content, $message ?: 'Expecting HTTP body content to be empty.');

--- a/src/HttpMessage.php
+++ b/src/HttpMessage.php
@@ -52,8 +52,8 @@ class HttpMessage implements ArrayAccess
      */
     public function __construct(
         int $status,
-        string $contentType = null,
-        string $content = null,
+        ?string $contentType = null,
+        ?string $content = null,
         array $headers = []
     ) {
         $this->status = $status;


### PR DESCRIPTION
Improve support for PHP 8.4 by removing deprecation notices.