### PR TITLE
feat: support phpunit 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,16 @@ jobs:
         php: [8.2, 8.3, 8.4]
         laravel: [10, 11, 12]
         phpunit: [10.5, 11, 12]
+        exclude:
+          - php: 8.2
+            laravel: 12
+            phpunit: 12
+          - php: 8.2
+            laravel: 11
+            phpunit: 12
+          - php: 8.2
+            laravel: 10
+            phpunit: 12
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         php: [8.2, 8.3, 8.4]
         laravel: [10, 11, 12]
-        phpunit: [10.5, 11]
+        phpunit: [10.5, 11, 12]
 
     steps:
       - name: Checkout Code

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-json": "*",
         "illuminate/contracts": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0",
-        "phpunit/phpunit": "^10.5|^11.0"
+        "phpunit/phpunit": "^10.5|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Assertions/FetchedManyTest.php
+++ b/tests/Assertions/FetchedManyTest.php
@@ -17,6 +17,7 @@ use CloudCreativity\JsonApi\Testing\HttpMessage;
 use CloudCreativity\JsonApi\Testing\Tests\TestCase;
 use CloudCreativity\JsonApi\Testing\Tests\TestModel;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FetchedManyTest extends TestCase
 {
@@ -363,8 +364,8 @@ class FetchedManyTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedManyArrayProvider
      */
+    #[DataProvider('fetchedManyArrayProvider')]
     public function testFetchedManyWithArray(bool $expected, Closure $provider): void
     {
         $value = $provider($this->post1, $this->post2, $this->post3);
@@ -383,8 +384,8 @@ class FetchedManyTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedManyArrayProvider
      */
+     #[DataProvider('fetchedManyArrayProvider')]
     public function testFetchedManyWithObject(bool $expected, Closure $provider): void
     {
         $value = $provider($this->post1, $this->post2, $this->post3);
@@ -677,8 +678,8 @@ class FetchedManyTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedManyInOrderArrayProvider
      */
+     #[DataProvider('fetchedManyInOrderArrayProvider')]
     public function testFetchedManyInOrderWithArray(bool $expected, Closure $provider): void
     {
         $value = $provider($this->post1, $this->post2, $this->post3);
@@ -697,8 +698,8 @@ class FetchedManyTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedManyInOrderArrayProvider
      */
+     #[DataProvider('fetchedManyInOrderArrayProvider')]
     public function testFetchedManyInOrderWithObject(bool $expected, Closure $provider): void
     {
         $value = $provider($this->post1, $this->post2, $this->post3);
@@ -879,8 +880,8 @@ class FetchedManyTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedManyExactArrayProvider
      */
+     #[DataProvider('fetchedManyExactArrayProvider')]
     public function testFetchedManyExactWithArray(bool $expected, Closure $provider): void
     {
         $value = $provider($this->post1, $this->post2, $this->post3);

--- a/tests/Assertions/FetchedOneTest.php
+++ b/tests/Assertions/FetchedOneTest.php
@@ -18,6 +18,7 @@ use CloudCreativity\JsonApi\Testing\Tests\TestCase;
 use CloudCreativity\JsonApi\Testing\Tests\TestModel;
 use CloudCreativity\JsonApi\Testing\Tests\TestObject;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FetchedOneTest extends TestCase
 {
@@ -244,8 +245,8 @@ class FetchedOneTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedOneArrayProvider
      */
+     #[DataProvider('fetchedOneArrayProvider')]
     public function testFetchedOneWithArray(bool $expected, Closure $provider): void
     {
         $value = $provider($this->resource);
@@ -264,8 +265,8 @@ class FetchedOneTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedOneArrayProvider
      */
+     #[DataProvider('fetchedOneArrayProvider')]
     public function testFetchedOneWithObject(bool $expected, Closure $provider): void
     {
         $value = $provider($this->resource);
@@ -426,8 +427,8 @@ class FetchedOneTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedOneExactArrayProvider
      */
+     #[DataProvider('fetchedOneExactArrayProvider')]
     public function testFetchedOneExactWithArray(bool $expected, Closure $provider): void
     {
         $value = $provider($this->resource);
@@ -446,8 +447,8 @@ class FetchedOneTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedOneExactArrayProvider
      */
+     #[DataProvider('fetchedOneExactArrayProvider')]
     public function testFetchedOneExactWithObject(bool $expected, Closure $provider): void
     {
         $value = $provider($this->resource);

--- a/tests/Assertions/FetchedToManyTest.php
+++ b/tests/Assertions/FetchedToManyTest.php
@@ -16,6 +16,7 @@ use CloudCreativity\JsonApi\Testing\HttpMessage;
 use CloudCreativity\JsonApi\Testing\Tests\TestCase;
 use CloudCreativity\JsonApi\Testing\Tests\TestModel;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FetchedToManyTest extends TestCase
 {
@@ -199,8 +200,8 @@ class FetchedToManyTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedToManyArrayProvider
      */
+     #[DataProvider('fetchedToManyArrayProvider')]
     public function testFetchedToManyWithArray(bool $expected, Closure $provider): void
     {
         $value = $provider($this->post1, $this->post2, $this->post3);
@@ -219,8 +220,8 @@ class FetchedToManyTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedToManyArrayProvider
      */
+     #[DataProvider('fetchedToManyArrayProvider')]
     public function testFetchedToManyWithObject(bool $expected, Closure $provider): void
     {
         $value = $provider($this->post1, $this->post2, $this->post3);
@@ -383,8 +384,8 @@ class FetchedToManyTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedToManyInOrderArrayProvider
      */
+     #[DataProvider('fetchedToManyInOrderArrayProvider')]
     public function testFetchedToManyInOrderWithArray(bool $expected, Closure $provider): void
     {
         $value = $provider($this->post1, $this->post2, $this->post3);
@@ -403,8 +404,8 @@ class FetchedToManyTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedToManyInOrderArrayProvider
      */
+     #[DataProvider('fetchedToManyInOrderArrayProvider')]
     public function testFetchedToManyInOrderWithObject(bool $expected, Closure $provider): void
     {
         $value = $provider($this->post1, $this->post2, $this->post3);

--- a/tests/Assertions/FetchedToOneTest.php
+++ b/tests/Assertions/FetchedToOneTest.php
@@ -17,6 +17,7 @@ use CloudCreativity\JsonApi\Testing\Tests\TestCase;
 use CloudCreativity\JsonApi\Testing\Tests\TestModel;
 use CloudCreativity\JsonApi\Testing\Tests\TestObject;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FetchedToOneTest extends TestCase
 {
@@ -130,8 +131,8 @@ class FetchedToOneTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedToOneArrayProvider
      */
+    #[DataProvider('fetchedToOneArrayProvider')]
     public function testFetchedOneWithArray(bool $expected, Closure $provider): void
     {
         $value = $provider($this->identifier);
@@ -150,8 +151,8 @@ class FetchedToOneTest extends TestCase
      * @param bool $expected
      * @param Closure $provider
      * @return void
-     * @dataProvider fetchedToOneArrayProvider
      */
+    #[DataProvider('fetchedToOneArrayProvider')]
     public function testFetchedOneWithObject(bool $expected, Closure $provider): void
     {
         $value = $provider($this->identifier);
@@ -230,8 +231,8 @@ class FetchedToOneTest extends TestCase
     /**
      * @param Closure $provider
      * @return void
-     * @dataProvider resourceProvider
      */
+    #[DataProvider('resourceProvider')]
     public function testFetchedToOneWithResource(Closure $provider): void
     {
         $value = $provider($this->identifier);

--- a/tests/Assertions/IncludedTest.php
+++ b/tests/Assertions/IncludedTest.php
@@ -16,6 +16,7 @@ use CloudCreativity\JsonApi\Testing\HttpMessage;
 use CloudCreativity\JsonApi\Testing\Tests\TestCase;
 use CloudCreativity\JsonApi\Testing\Tests\TestModel;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class IncludedTest extends TestCase
 {
@@ -162,8 +163,8 @@ class IncludedTest extends TestCase
      * @param string $type
      * @param string $id
      * @return void
-     * @dataProvider isIncludedProvider
      */
+    #[DataProvider('isIncludedProvider')]
     public function testIsIncludedWithUrlRoutable(bool $expected, string $type, string $id): void
     {
         $model = new TestModel((int) $id);
@@ -183,8 +184,8 @@ class IncludedTest extends TestCase
      * @param string $type
      * @param string $id
      * @return void
-     * @dataProvider isIncludedProvider
      */
+    #[DataProvider('isIncludedProvider')]
     public function testIsIncludedWithString(bool $expected, string $type, string $id): void
     {
         if ($expected) {
@@ -202,8 +203,8 @@ class IncludedTest extends TestCase
      * @param string $type
      * @param string $id
      * @return void
-     * @dataProvider isIncludedProvider
      */
+    #[DataProvider('isIncludedProvider')]
     public function testIsIncludedWithInteger(bool $expected, string $type, string $id): void
     {
         $id = (int) $id;

--- a/tests/Assertions/MetaTest.php
+++ b/tests/Assertions/MetaTest.php
@@ -15,6 +15,7 @@ use Carbon\Carbon;
 use CloudCreativity\JsonApi\Testing\HttpMessage;
 use CloudCreativity\JsonApi\Testing\Tests\TestCase;
 use CloudCreativity\JsonApi\Testing\Tests\TestObject;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class MetaTest extends TestCase
 {
@@ -82,8 +83,8 @@ class MetaTest extends TestCase
     /**
      * @param int $status
      * @return void
-     * @dataProvider statusCodeProvider
      */
+    #[DataProvider('statusCodeProvider')]
     public function testMetaWithoutData(int $status): void
     {
         $http = $this->http->withStatusCode($status);
@@ -109,8 +110,8 @@ class MetaTest extends TestCase
     /**
      * @param int $status
      * @return void
-     * @dataProvider statusCodeProvider
      */
+    #[DataProvider('statusCodeProvider')]
     public function testExactMetaWithoutData(int $status): void
     {
         $http = $this->http->withStatusCode($status);
@@ -160,8 +161,8 @@ class MetaTest extends TestCase
      * @param int $status
      * @param string $expected
      * @return void
-     * @dataProvider invalidStatusCodeProvider
      */
+    #[DataProvider('invalidStatusCodeProvider')]
     public function testInvalidStatusCode(int $status, string $expected = ''): void
     {
         $expected = $expected ?: "HTTP status {$status} is successful";


### PR DESCRIPTION
Support PHPUnit 12. The `DataProvider` attribute is supported since PHPUnit 10, so this is a non-breaking change.